### PR TITLE
Changed prepare samples to use np array for X

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -203,9 +203,16 @@ def viewer(sample):
 def prepare(samples):
     print("Preparing data")
 
-    X = []
     y = []
-
+    
+    for sample in samples:
+        image_files = load_imgs(sample)
+        numpics += len(image_files)
+        
+    X = np.empty(shape=(numpics,Sample.IMG_H,Sample.IMG_W,3),dtype=np.uint8)
+    print(f"There are {numpics} samples")
+    
+    idx = 0
     for sample in samples:
         print(sample)
 
@@ -219,10 +226,10 @@ def prepare(samples):
         for image_file in image_files:
             image = imread(image_file)
             vec = resize_image(image)
-            X.append(vec)
+            X[idx] = vec
+            idx += 1
 
     print("Saving to file...")
-    X = np.asarray(X)
     y = np.concatenate(y)
 
     np.save("data/X", X)


### PR DESCRIPTION
The previous method, with a list, took too much memory. With the old method, using 20 GB worth of 1080p images, memory usage would exceed my computer's 16 GB. With the updated code it does not exceed 1 GB. Kind of solved this issue: https://github.com/kevinhughes27/TensorKart/issues/2